### PR TITLE
fix(7): add extra space when replacing breaking line

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -129,7 +129,7 @@ function parseButtonLabel(label: string): LinkedInSectionName {
 
 function parseText(elm: Cheerio<Element>, removeBreaklines = true): string {
   if (removeBreaklines) {
-    return elm.text().replace(/\n/g, '').trim();
+    return elm.text().replace(/\n/g, ' ').trim();
   } else {
     return elm.text().trim();
   }


### PR DESCRIPTION
- Fixes #[Issue](https://github.com/lightning-resume/linkedin-resume-parser/issues/7)
